### PR TITLE
Push notification null content

### DIFF
--- a/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/SharedPreferencesUtils.kt
+++ b/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/SharedPreferencesUtils.kt
@@ -17,7 +17,7 @@ private fun initInstance(context: Context) {
 
 
 fun addCall(context: Context?, data: Data, isAccepted: Boolean = false) {
-    val json = getString(context, "ACTIVE_CALLS", "[]")
+    val json = getString(context, "ACTIVE_CALLS", "[]") ?: "[]"
     val arrayData: ArrayList<Data> = Utils.getGsonInstance()
         .readValue(json, object : TypeReference<ArrayList<Data>>() {})
     val currentData = arrayData.find { it == data }
@@ -31,7 +31,7 @@ fun addCall(context: Context?, data: Data, isAccepted: Boolean = false) {
 }
 
 fun removeCall(context: Context?, data: Data) {
-    val json = getString(context, "ACTIVE_CALLS", "[]")
+    val json = getString(context, "ACTIVE_CALLS", "[]") ?: "[]"
     val arrayData: ArrayList<Data> = Utils.getGsonInstance()
         .readValue(json, object : TypeReference<ArrayList<Data>>() {})
     arrayData.remove(data)
@@ -44,13 +44,13 @@ fun removeAllCalls(context: Context?) {
 }
 
 fun getDataActiveCalls(context: Context?): ArrayList<Data> {
-    val json = getString(context, "ACTIVE_CALLS", "[]")
+    val json = getString(context, "ACTIVE_CALLS", "[]") ?: "[]"
     return Utils.getGsonInstance()
         .readValue(json, object : TypeReference<ArrayList<Data>>() {})
 }
 
 fun getDataActiveCallsForFlutter(context: Context?): ArrayList<Map<String, Any?>> {
-    val json = getString(context, "ACTIVE_CALLS", "[]")
+    val json = getString(context, "ACTIVE_CALLS", "[]") ?: "[]"
     return Utils.getGsonInstance().readValue(json, object : TypeReference<ArrayList<Map<String, Any?>>>() {})
 }
 


### PR DESCRIPTION
### 🎯 Goal

Fix `PlatformException(error, argument "content" is null, , null)` occurring when `SharedPreferencesUtils.getString()` returns `null`, causing `ObjectMapper.readValue()` to throw an `IllegalArgumentException`.

### 🛠 Implementation details

Added a null-coalescing operator (`?: "[]"`) to all calls to `getString()` within `SharedPreferencesUtils.kt`. This ensures that `ObjectMapper.readValue()` always receives a valid JSON string (an empty array `[]`) instead of `null`, preventing the `IllegalArgumentException`.

The affected functions are:
- `addCall()`
- `removeCall()`
- `getDataActiveCalls()`
- `getDataActiveCallsForFlutter()`

### 🎨 UI Changes

No UI changes.

### 🧪 Testing

To test this change, ensure that the application handles scenarios where `SharedPreferencesUtils.getString()` might return `null` (e.g., when the context is null or the key does not exist) without crashing due to the "argument content is null" error.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation

---
<a href="https://cursor.com/background-agent?bcId=bc-6a73c255-7900-4ad1-83d3-1fccdab60265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a73c255-7900-4ad1-83d3-1fccdab60265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures JSON parsing never receives null for `ACTIVE_CALLS`, avoiding `IllegalArgumentException` during deserialization.
> 
> - In `SharedPreferencesUtils.kt`, added `?: "[]"` to `getString(..., "[]")` results in `addCall`, `removeCall`, `getDataActiveCalls`, and `getDataActiveCallsForFlutter` so JSON parsing always uses an empty array when the preference is missing/null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb662bbe4cc7c69214370dc27016b503d74cd151. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->