### PR TITLE
fix: always update context in initSharedInstance to prevent null context

### DIFF
--- a/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/StreamVideoPushNotificationPlugin.kt
+++ b/packages/stream_video_push_notification/android/src/main/kotlin/io/getstream/video/flutter/stream_video_push_notification/StreamVideoPushNotificationPlugin.kt
@@ -67,8 +67,9 @@ class StreamVideoPushNotificationPlugin: FlutterPlugin, MethodCallHandler, Activ
                 instance = StreamVideoPushNotificationPlugin()
                 instance.incomingCallSoundPlayerManager = IncomingCallSoundPlayerManager(context)
                 instance.incomingCallNotificationManager = IncomingCallNotificationManager(context, instance.incomingCallSoundPlayerManager)
-                instance.context = context
             }
+            // Always update context to ensure it's valid for the current engine
+            instance.context = context
 
             val channel = MethodChannel(binaryMessenger, "stream_video_push_notification")
             methodChannels[binaryMessenger] = channel


### PR DESCRIPTION
Root cause: instance.context was only set when the instance was first initialized. If a new FlutterEngine attaches to an already initialized instance (e.g., when app restarts from terminated state with a push notification), the context would remain null or stale.

This fix moves context assignment outside the initialization check, ensuring context is always updated with the current engine's context.

### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

_Describe the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="" controls="controls" muted="muted" />
</td>
<td>
<video src="" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Provide the patch code here
```

</details>


### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#flutter-team) (required)
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] Sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated Documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the plugin always holds a valid `Context` for the active engine.
> 
> - In `initSharedInstance`, moves `instance.context = context` outside the initialization guard so the context is refreshed on every call, preventing stale/null context when a new `FlutterEngine` attaches
> - No other functional changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 305504a2cc5e749235d9a6d1b554a84ff0a29474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->